### PR TITLE
fix  'openssl_fips' is not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "node-gyp rebuild",
-    "build32": "node-gyp clean configure build --arch=ia32",
-    "build64": "node-gyp clean configure build --arch=x64",
+    "install": "node-gyp rebuild --openssl_fips=''",
+    "build32": "node-gyp clean configure build --arch=ia32 --openssl_fips=''",
+    "build64": "node-gyp clean configure build --arch=x64 --openssl_fips=''",
     "buildtest": "cd test && MSBuild.exe project.sln //p:Configuration=Release"
   },
   "repository": {


### PR DESCRIPTION
fix https://github.com/nodejs/node-gyp/issues/2673

error log
```
gyp: name 'openssl_fips' is not defined while evaluating condition 'openssl_fips != ""' in binding.gyp while trying to load binding.gyp
gyp ERR! configure error
gyp ERR! stack Error: gyp failed with exit code: 1
```